### PR TITLE
Removendo link Clientes do navbar

### DIFF
--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -106,11 +106,11 @@ const Navbar = ({ ...rest }) => {
             Empresa
           </NavbarLink>
         </NavbarLinkItem>
-        <NavbarLinkItem>
+        {/* <NavbarLinkItem>
           <NavbarLink onClick={() => { scrollTo("#clientes"); setHiddenMobileNavbar(true); }}>
             Clientes
           </NavbarLink>
-        </NavbarLinkItem>
+        </NavbarLinkItem> */}
         <NavbarLinkItem>
           <NavbarLink onClick={() => { scrollTo("#portfolio"); setHiddenMobileNavbar(true); }}>
             Portfólio


### PR DESCRIPTION
Na Navbar ainda constava o link de Clientes, mesmo a seção tendo sido removida do site
## Navbar antes
![image](https://user-images.githubusercontent.com/47929434/120250977-5a20b100-c256-11eb-8c6f-015e3dc05883.png)
## Navbar depois
![image](https://user-images.githubusercontent.com/47929434/120250992-6a389080-c256-11eb-9343-ae20d6c9665c.png)
