### PR TITLE
Hover diminui opacidade dos botões da Navbar

### DIFF
--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -83,6 +83,9 @@ const NavbarLink = styled.button`
   outline: none;
   border: 0px;
   cursor: pointer;
+  :hover {
+    opacity: 0.5;
+  }
 `
 
 const StyledBurger = styled(Burger)`


### PR DESCRIPTION
Adicionado efeito de hover nos botões da navbar. Testei mudar de cor pro roxo, mas ficou escuro demais, achei melhor diminuir a opacidade.
![image](https://user-images.githubusercontent.com/73000207/127753178-34e334e9-ff09-4808-a983-461169b52f2f.png)
